### PR TITLE
Add border radius to thumbnails like in Files app

### DIFF
--- a/src/components/RecommendedFile.vue
+++ b/src/components/RecommendedFile.vue
@@ -139,6 +139,7 @@
 		height: 32px;
 		background-size: contain;
 		flex-shrink: 0;
+		border-radius: var(--border-radius);
 	}
 
 	.details {


### PR DESCRIPTION
Before & after:
![recommendation thumbnail before](https://user-images.githubusercontent.com/925062/54198161-164eff00-44c6-11e9-8454-eb972082e691.png)
![recommendation thumbnail after](https://user-images.githubusercontent.com/925062/54198163-164eff00-44c6-11e9-88f9-55a6ea9bbba2.png)
