### PR TITLE
Do less DB requests when fetching parent path

### DIFF
--- a/lib/Service/RecentlyEditedFilesSource.php
+++ b/lib/Service/RecentlyEditedFilesSource.php
@@ -53,8 +53,12 @@ class RecentlyEditedFilesSource implements IRecommendationSource {
 
 		return array_filter(array_map(function (Node $node) use ($userFolder) {
 			try {
+				$parentPath = dirname($node->getPath());
+				if ($parentPath === '' || $parentPath === '.' || $parentPath === '/') {
+					$parentPath = $node->getParent()->getPath();
+				}
 				return new RecommendedFile(
-					$userFolder->getRelativePath($node->getParent()->getPath()),
+					$userFolder->getRelativePath($parentPath),
 					$node,
 					$node->getMTime(),
 					$this->l10n->t("Recently edited")


### PR DESCRIPTION
Only fetch the parent path from the db if the parent is the storage
root. Unfortunately $this->root is not exposed in the Node api so we
can't save this call too.

In my tests previously the api call in the file app did 24 DB requests
and now only 17