### PR TITLE
Bump minimist from 1.2.5 to 1.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
 				"eslint-plugin-promise": "^6.0.0",
 				"eslint-plugin-standard": "^4.1.0",
 				"eslint-plugin-vue": "^6.2.2",
+				"minimist": "^1.2.6",
 				"sass-loader": "^10.1.1",
 				"style-loader": "^2.0.0",
 				"stylelint": "^14.9.1",
@@ -8956,9 +8957,9 @@
 			}
 		},
 		"node_modules/minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"node_modules/minimist-options": {
 			"version": "4.1.0",
@@ -21121,9 +21122,9 @@
 			}
 		},
 		"minimist": {
-			"version": "1.2.5",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+			"version": "1.2.6",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
 		},
 		"minimist-options": {
 			"version": "4.1.0",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
 		"eslint-plugin-promise": "^6.0.0",
 		"eslint-plugin-standard": "^4.1.0",
 		"eslint-plugin-vue": "^6.2.2",
+		"minimist": "^1.2.6",
 		"sass-loader": "^10.1.1",
 		"style-loader": "^2.0.0",
 		"stylelint": "^14.9.1",


### PR DESCRIPTION
Added to dev deps

```
% npm ls minimist
files_recommendation@1.4.0 /srv/www/htdocs/server/apps-extra/recommendations
├─┬ eslint-loader@3.0.4
│ └─┬ loader-utils@1.2.3
│   └─┬ json5@1.0.1
│     └── minimist@1.2.6 deduped
├─┬ eslint-plugin-import@2.25.4
│ └─┬ tsconfig-paths@3.12.0
│   ├─┬ json5@1.0.1
│   │ └── minimist@1.2.6 deduped
│   └── minimist@1.2.6 deduped
├─┬ eslint@6.8.0 invalid: "^7.0.0 || ^8.0.0" from node_modules/eslint-plugin-promise
│ └─┬ mkdirp@0.5.5
│   └── minimist@1.2.6 deduped
├── minimist@1.2.6
└─┬ sass-loader@10.1.1
  └─┬ node-sass@5.0.0
    └─┬ meow@3.7.0
      └── minimist@1.2.6 deduped
```