### PR TITLE
Replace "Recommanded files" with "Recent files" because it seems to be nothing but recent files

### DIFF
--- a/lib/Dashboard/RecommendationWidget.php
+++ b/lib/Dashboard/RecommendationWidget.php
@@ -69,7 +69,7 @@ class RecommendationWidget implements IWidget, IIconWidget, IAPIWidget {
 	}
 
 	public function getTitle(): string {
-		return $this->l10n->t('Recommended files');
+		return $this->l10n->t('Recent files');
 	}
 
 	public function getOrder(): int {


### PR DESCRIPTION
Signed-off-by: Jérôme Herbinet <33763786+Jerome-Herbinet@users.noreply.github.com>

Replace "Recommanded files" with "Recent files" because it seems to be nothing but recent files and so that this title is consistent with the title of the activities widget : "Recent" activity