### PR TITLE
fix: catch and filter shares whom storage is not available

### DIFF
--- a/lib/Service/RecentlySharedFilesSource.php
+++ b/lib/Service/RecentlySharedFilesSource.php
@@ -12,6 +12,7 @@ namespace OCA\Recommendations\Service;
 use Generator;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
+use OCP\Files\StorageNotAvailableException;
 use OCP\IL10N;
 use OCP\IUser;
 use OCP\Share\IManager;
@@ -102,6 +103,8 @@ class RecentlySharedFilesSource implements IRecommendationSource {
 					$this->l10n->t("Recently shared")
 				);
 			} catch (NotFoundException $ex) {
+				return null;
+			} catch (StorageNotAvailableException $e) {
 				return null;
 			}
 		}, $shares));


### PR DESCRIPTION
Fails for me otherwise (I have a lot of shared external storages and incoming federated shares)