### PR TITLE
fix: add missing description to command

### DIFF
--- a/lib/Command/GetRecommendations.php
+++ b/lib/Command/GetRecommendations.php
@@ -30,6 +30,7 @@ class GetRecommendations extends Command {
 
 	protected function configure() {
 		$this->setName('files:recommendations:recommend');
+		$this->setDescription('Shows recommended files for an account');
 		$this->addArgument(
 			'uid',
 			InputArgument::REQUIRED,


### PR DESCRIPTION
Came up while doing nextcloud/documentation#12387

After:

```
Available commands for the "files" namespace:
[...]
  files:put                        Write contents of a file
  files:recommendations:recommend  Shows recommended files for an account
  files:reminders                  List file reminders
[...]
```

Before:

```
Available commands for the "files" namespace:
[...]
  files:put                        Write contents of a file
  files:recommendations:recommend  
  files:reminders                  List file reminders
[...]
```