### PR TITLE
perf(recommendations): avoid scanning all commented files

### DIFF
--- a/lib/Service/RecentlyCommentedFilesSource.php
+++ b/lib/Service/RecentlyCommentedFilesSource.php
@@ -2,45 +2,20 @@
 
 /**
  * SPDX-FileCopyrightText: 2018 Nextcloud GmbH and Nextcloud contributors
+ * SPDX-FileCopyrightText: 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
 declare(strict_types=1);
 
-/**
- * @copyright 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
- *
- * @author 2019 Christoph Wurst <christoph@winzerhof-wurst.at>
- *
- * @license GNU AGPL version 3 or any later version
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- */
-
 namespace OCA\Recommendations\Service;
 
-use Generator;
 use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
 use OCP\IL10N;
 use OCP\IUser;
-use function array_map;
-use function array_slice;
-use function iterator_to_array;
-use function usort;
 
 class RecentlyCommentedFilesSource implements IRecommendationSource {
 
@@ -49,11 +24,15 @@ class RecentlyCommentedFilesSource implements IRecommendationSource {
 	public function __construct(
 		private readonly ICommentsManager $commentsManager,
 		private readonly IRootFolder $rootFolder,
-		private readonly IL10N $l10n,
 	) {
 	}
 
+	/**
+	 * @return IComment[]
+	 */
 	private function getCommentsPage(int $offset, int $pageSize): array {
+		// Comment search returns newest comments first, so the first resolvable
+		// unique file IDs we encounter are the most recent recommendations.
 		return $this->commentsManager->search(
 			'',
 			'files',
@@ -78,63 +57,58 @@ class RecentlyCommentedFilesSource implements IRecommendationSource {
 	}
 
 	/**
-	 * @param IUser $user
-	 *
-	 * @return Generator<FileWithComments>
-	 */
-	private function getAllCommentedFiles(IUser $user): Generator {
-		$offset = 0;
-		$pageSize = 100;
-
-		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
-
-		while (count($page = $this->getCommentsPage($offset, $pageSize)) > 0) {
-			foreach ($page as $comment) {
-				$commentedFile = $this->getCommentedFile($comment, $userFolder);
-				if (!is_null($commentedFile)) {
-					yield $commentedFile;
-				}
-			}
-
-			$offset += $pageSize;
-		}
-	}
-
-	/**
-	 * @param FileWithComments[] $original
-	 * @return FileWithComments[]
-	 */
-	private function sortCommentedFiles(array $original): array {
-		usort($original, function (FileWithComments $a, FileWithComments $b) {
-			return $b->getComment()->getCreationDateTime()->getTimestamp() - $a->getComment()->getCreationDateTime()->getTimestamp();
-		});
-		return $original;
-	}
-
-	/**
-	 * @param FileWithComments[] $comments
-	 * @return FileWithComments[]
-	 */
-	private function getNMostRecentlyCommenedFiles(array $comments, int $n): array {
-		$sorted = $this->sortCommentedFiles($comments);
-
-		return array_slice($sorted, 0, $n);
-	}
-
-	/**
 	 * @return IRecommendation[]
 	 */
 	#[\Override]
 	public function getMostRecentRecommendation(IUser $user, int $max): array {
-		$all = iterator_to_array($this->getAllCommentedFiles($user));
+		if ($max <= 0) {
+			return [];
+		}
 
-		return array_map(function (FileWithComments $file) {
-			return new RecommendedFile(
-				$file->getDirectory(),
-				$file->getNode(),
-				$file->getComment()->getCreationDateTime()->getTimestamp(),
-				self::REASON,
-			);
-		}, $this->getNMostRecentlyCommenedFiles($all, $max));
+		$offset = 0;
+		$pageSize = 100;
+		$results = [];
+		$seenFileIds = [];
+
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+
+		while (count($results) < $max) {
+			$page = $this->getCommentsPage($offset, $pageSize);
+			if ($page === []) {
+				break;
+			}
+
+			foreach ($page as $comment) {
+				$fileId = (int)$comment->getObjectId();
+				if (isset($seenFileIds[$fileId])) {
+					continue;
+				}
+
+				$commentedFile = $this->getCommentedFile($comment, $userFolder);
+				if ($commentedFile === null) {
+					continue;
+				}
+
+				$seenFileIds[$fileId] = true;
+				$results[] = new RecommendedFile(
+					$commentedFile->getDirectory(),
+					$commentedFile->getNode(),
+					$comment->getCreationDateTime()->getTimestamp(),
+					self::REASON,
+				);
+
+				if (count($results) >= $max) {
+					break 2;
+				}
+			}
+
+			if (count($page) < $pageSize) {
+				break;
+			}
+
+			$offset += $pageSize;
+		}
+
+		return $results;
 	}
 }

--- a/lib/Service/RecentlyCommentedFilesSource.php
+++ b/lib/Service/RecentlyCommentedFilesSource.php
@@ -14,7 +14,6 @@ use OCP\Comments\IComment;
 use OCP\Comments\ICommentsManager;
 use OCP\Files\Folder;
 use OCP\Files\IRootFolder;
-use OCP\IL10N;
 use OCP\IUser;
 
 class RecentlyCommentedFilesSource implements IRecommendationSource {

--- a/lib/Service/RecentlyCommentedFilesSource.php
+++ b/lib/Service/RecentlyCommentedFilesSource.php
@@ -83,12 +83,13 @@ class RecentlyCommentedFilesSource implements IRecommendationSource {
 					continue;
 				}
 
+				$seenFileIds[$fileId] = true;
+
 				$commentedFile = $this->getCommentedFile($comment, $userFolder);
 				if ($commentedFile === null) {
 					continue;
 				}
 
-				$seenFileIds[$fileId] = true;
 				$results[] = new RecommendedFile(
 					$commentedFile->getDirectory(),
 					$commentedFile->getNode(),


### PR DESCRIPTION
## Summary

Optimize `RecentlyCommentedFilesSource::getMostRecentRecommendation()` to short-circuit comment scanning once enough unique files have been identified.

LIkely fixes #522

## What changed

- **Refactored flow:** Replaced the previous `load all -> sort -> slice` logic in `lib/Service/RecentlyCommentedFilesSource.php` with a streaming approach.
- **Incremental iteration:** Iterate through comment pages in recency order.
- **In-flight deduplication:** Deduplicate by file ID while iterating.
- **Early exit:** Stop processing once the required number of recommendations has been collected.
- **End-of-result handling:** Stop paging when a retrieved page is shorter than the requested page size.

## Why

`ICommentsManager::search()` already returns comments ordered by recency, so collecting and sorting the full result set was unnecessary for this code path.

This reduces:

- PHP memory usage
- CPU overhead from sorting
- unnecessary database paging
- repeated processing of duplicate comments for the same file

## Profiler impact

For a fresh installation with a single commented file, the extra "empty page" query is now eliminated:

- **Before:** two `SELECT` queries for comments (initial page plus a second page to check for more results)
- **After:** one `SELECT` query for comments in this profiled case

## Estimated impact on larger installations

On instances with a large comment history, performance should now scale much more closely with the **number of comments that need to be scanned to find enough unique recent files** rather than the **total comment count**.

In practice, this should help reduce work in three ways:

- **Database:** installations with many comments may drop from several paged comment queries to just the first one or first few pages
- **Compute:** PHP work drops from processing the full result set plus sorting to processing only the comments scanned until enough results are found
- **Memory:** the full result set no longer needs to be materialized before slicing

The exact improvement will still depend on factors such as:

- how many total comments exist
- how many recent comments point to the same files
- how many commented files are resolvable for the user

## Notes

- Preserves the existing behavior of returning the most recent commented files.
- Relies on the currently observed `search()` ordering: `ORDER BY creation_timestamp DESC, id DESC`.
