### PR TITLE
perf(recommendations): reduce memory usage when ranking shared files

### DIFF
--- a/lib/Service/RecentlySharedFilesSource.php
+++ b/lib/Service/RecentlySharedFilesSource.php
@@ -9,108 +9,145 @@ declare(strict_types=1);
 
 namespace OCA\Recommendations\Service;
 
-use Generator;
 use OCP\Files\IRootFolder;
 use OCP\Files\NotFoundException;
 use OCP\Files\StorageNotAvailableException;
-use OCP\IL10N;
 use OCP\IUser;
 use OCP\Share\IManager;
 use OCP\Share\IShare;
-use function array_filter;
-use function array_map;
-use function array_merge;
 use function array_slice;
-use function iterator_to_array;
 use function usort;
 
 class RecentlySharedFilesSource implements IRecommendationSource {
 
 	public const REASON = 'recently-shared';
 
-	private IManager $shareManager;
-	private IRootFolder $rootFolder;
-	private IL10N $l10n;
-
-	public function __construct(IManager $shareManager,
-		IRootFolder $rootFolder,
-		IL10N $l10n) {
-		$this->shareManager = $shareManager;
-		$this->rootFolder = $rootFolder;
-		$this->l10n = $l10n;
+	public function __construct(
+		private IManager $shareManager,
+		private IRootFolder $rootFolder,
+	) {
 	}
 
 	/**
-	 * @return Generator<IShare>
+	 * @return IShare[]
 	 */
-	private function getAllShares(IUser $user, int $shareType): Generator {
-		$offset = 0;
-		$pageSize = 50;
-
-		while (count($page = $this->shareManager->getSharedWith(
+	private function getSharesPage(IUser $user, int $shareType, int $offset, int $pageSize): array {
+		return $this->shareManager->getSharedWith(
 			$user->getUID(),
 			$shareType,
 			null,
 			$pageSize,
 			$offset
-		))) {
-			foreach ($page as $share) {
-				yield $share;
-			}
-
-			$offset += $pageSize;
-		}
+		);
 	}
 
 	/**
-	 * @param IShare[] $shares
-	 *
-	 * @return IShare[]
+	 * @param list<IShare> $shares
+	 * @return list<IShare>
 	 */
-	private function sortShares(array $shares): array {
-		usort($shares, function (IShare $a, IShare $b) {
-			return $b->getShareTime()->getTimestamp() - $a->getShareTime()->getTimestamp();
+	private function sortSharesByMostRecent(array $shares): array {
+		usort($shares, static function (IShare $a, IShare $b): int {
+			return $b->getShareTime()->getTimestamp() <=> $a->getShareTime()->getTimestamp();
 		});
+
 		return $shares;
 	}
 
 	/**
-	 * @param IUser $user
+	 * Merge a new batch of shares into the current top-N list.
 	 *
-	 * @todo load other share types as well
+	 * We intentionally do not assume that getSharedWith() is ordered by
+	 * share time, so every fetched page must still be considered.
 	 *
-	 * @return IShare[]
+	 * @param list<IShare> $topShares
+	 * @param list<IShare> $page
+	 * @return list<IShare>
 	 */
-	private function getMostRecentShares(IUser $user, int $max): array {
-		$shares = $this->sortShares(array_merge(
-			iterator_to_array($this->getAllShares($user, IShare::TYPE_USER)),
-			iterator_to_array($this->getAllShares($user, IShare::TYPE_GROUP))
-		));
+	private function mergeTopShares(array $topShares, array $page, int $max): array {
+		if ($page === []) {
+			return $topShares;
+		}
 
-		return array_slice($shares, 0, $max);
+		$merged = [...$topShares, ...$page];
+		$merged = $this->sortSharesByMostRecent($merged);
+
+		if (count($merged) > $max) {
+			$merged = array_slice($merged, 0, $max);
+		}
+
+		return $merged;
 	}
 
 	/**
-	 * @return IRecommendation[]
+	 * Return the globally most recent shares across the supported share types.
+	 *
+	 * This preserves the existing behavior of considering all shares before
+	 * choosing the top results, while avoiding materializing the complete
+	 * merged share list in memory.
+	 *
+	 * @return list<IShare>
+	 */
+	private function getMostRecentShares(IUser $user, int $max): array {
+		if ($max <= 0) {
+			return [];
+		}
+
+		$pageSize = 50;
+		$topShares = [];
+
+		// @todo load other share types as well
+		foreach ([IShare::TYPE_USER, IShare::TYPE_GROUP] as $shareType) {
+			$offset = 0;
+
+			while (true) {
+				$page = $this->getSharesPage($user, $shareType, $offset, $pageSize);
+				if ($page === []) {
+					break;
+				}
+
+				$topShares = $this->mergeTopShares($topShares, $page, $max);
+
+				// Short page means pagination for this share type is exhausted.
+				// This is only an end-of-results check; it does not assume any
+				// recency ordering from getSharedWith().
+				if (count($page) < $pageSize) {
+					break;
+				}
+
+				$offset += $pageSize;
+			}
+		}
+
+		return $topShares;
+	}
+
+	/**
+	 * @return list<IRecommendation>
 	 */
 	#[\Override]
 	public function getMostRecentRecommendation(IUser $user, int $max): array {
-		$shares = $this->getMostRecentShares($user, $max);
-		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		if ($max <= 0) {
+			return [];
+		}
 
-		return array_filter(array_map(function (IShare $share) use ($userFolder): ?RecommendedFile {
+		$userFolder = $this->rootFolder->getUserFolder($user->getUID());
+		$recommendations = [];
+
+		foreach ($this->getMostRecentShares($user, $max) as $share) {
 			try {
-				return new RecommendedFile(
+				$recommendations[] = new RecommendedFile(
 					$userFolder->getRelativePath($userFolder->get($share->getTarget())->getParent()->getPath()),
 					$share->getNode(),
 					$share->getShareTime()->getTimestamp(),
 					self::REASON,
 				);
-			} catch (NotFoundException $ex) {
-				return null;
+			} catch (NotFoundException $e) {
+				continue;
 			} catch (StorageNotAvailableException $e) {
-				return null;
+				continue;
 			}
-		}, $shares));
+		}
+
+		return $recommendations;
 	}
 }


### PR DESCRIPTION
## Summary

Refactor `RecentlySharedFilesSource` to maintain a running bounded top-N list during pagination, replacing the previous approach of materializing the full merged share list before sorting.

## What changed

- Replace the previous `load all → merge → sort → slice` flow in `lib/Service/RecentlySharedFilesSource.php`.
- Page through supported share types incrementally.
- Maintain a bounded top-`N` list of shares ranked by `shareTime`, merging one page at a time.
- Preserve existing ranking behavior by continuing to scan all available pages for each supported share type.
- Streamline recommendation construction using an explicit single-pass loop in place of a nested `array_map` / `array_filter` / `array_values` pipeline.

## Why

`getSharedWith()` in `nextcloud/server` is not ordered by recency, so we cannot safely optimize by fetching only the first page. However, by accumulating a rolling top-N rather than collecting all shares first, this refactor avoids the memory overhead of materializing the full share list.

This change reduces:
- **Peak memory usage** — the working set is bounded to roughly `max + pageSize` shares rather than the full accumulated share list
- **Sort input size** — each merge sorts at most `max + pageSize` entries rather than the complete accumulated list

while preserving existing result semantics.

## Notes

- This change does **not** assume `getSharedWith()` is sorted by `shareTime`.
- Correctness is maintained by scanning all pages while retaining only the best `N` shares seen so far.
- Supported share types remain unchanged (`TYPE_USER` and `TYPE_GROUP`).

## Follow-up opportunity

This change optimizes the app-side ranking logic, but `getSharedWith()` in `nextcloud/server` is not recency-ordered, so correctness still requires scanning all pages.

A future server-side API that exposes incoming shares ordered by `shareTime`/`stime` could enable a stronger end-to-end optimization here by allowing early termination once enough recent results are found.