### PR TITLE
ci(renovate): ignore workflows managed by the org template repo

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -39,6 +39,27 @@
 		"php",
 		"postcss-loader"
 	],
+	"ignorePaths": [
+		".github/workflows/block-merge-freeze.yml",
+		".github/workflows/command-compile.yml",
+		".github/workflows/command-openapi.yml",
+		".github/workflows/dependabot-approve-merge.yml",
+		".github/workflows/lint-eslint.yml",
+		".github/workflows/lint-php.yml",
+		".github/workflows/lint-php-cs.yml",
+		".github/workflows/npm-audit-fix.yml",
+		".github/workflows/npm-build.yml",
+		".github/workflows/openapi.yml",
+		".github/workflows/phpunit-mariadb.yml",
+		".github/workflows/phpunit-mysql.yml",
+		".github/workflows/phpunit-oci.yml",
+		".github/workflows/phpunit-pgsql.yml",
+		".github/workflows/phpunit-sqlite.yml",
+		".github/workflows/pr-feedback.yml",
+		".github/workflows/psalm-matrix.yml",
+		".github/workflows/reuse.yml",
+		".github/workflows/sync-workflow-templates.yml"
+	],
 	"packageRules": [
 		{
 			"description": "Request JavaScript reviews",


### PR DESCRIPTION
These workflows are synced as a whole from the organization template repository, so Renovate must not bump their action versions. Any such bumps would be lost updates, overwritten by the next template sync.

Examples:
* https://github.com/nextcloud/recommendations/pull/1068
* https://github.com/nextcloud/recommendations/pull/1067
* https://github.com/nextcloud/recommendations/pull/1070

Assisted-by: ClaudeCode:claude-fable-5



## 🤖 AI (if applicable)

- [x] The content of this PR was partly or fully generated using AI
